### PR TITLE
tagging variable shift study histograms

### DIFF
--- a/analyzers/analyzer_histograms.C
+++ b/analyzers/analyzer_histograms.C
@@ -794,18 +794,19 @@ Bool_t analyzer_histograms::fillAODCaloJetStudyHistograms(Float_t weight, int se
     // only fill these once (no jet multiplicity)
     for(unsigned int i =0; i<aodcalojet_list.size(); i++){
       int aodcalojetindex = aodcalojet_list[i];
-      //std::cout<<"AODCaloJetAvfVertexTrackEnergy"<<AODCaloJetAvfVertexTrackEnergy->at(aodcalojetindex)<<" "<<aodcalojetindex<<std::endl;
+      // std::cout<<"AODCaloJetAvfVertexTrackEnergy"<<AODCaloJetAvfVertexTrackEnergy->at(0)<<" "<<aodcalojetindex<<std::endl;
+      // std::cout<<" "<<AODCaloJetAvfVertexTrackEnergy->size()<<" "<<AODCaloJetNCleanMatchedTracks->at( aodcalojetindex )<<std::endl;
       if(aodcalojetindex==0){
        h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
        h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
        h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
       }
-      if(AODCaloJetAvfVertexTrackEnergy->at(aodcalojetindex)>0.5){
+      if(AODCaloJetAvfVertexTrackEnergy->at(0)>0.5){
        h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
        h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
        h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
       }
-      if(AODCaloJetAvfVertexTrackEnergy->at(aodcalojetindex)>10.){
+      if(AODCaloJetAvfVertexTrackEnergy->at(0)>10.){
        h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
        h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
        h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
@@ -814,32 +815,38 @@ Bool_t analyzer_histograms::fillAODCaloJetStudyHistograms(Float_t weight, int se
       h_AODCaloJet_Study_n_v_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetNCleanMatchedTracks->at(aodcalojetindex) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
       h_AODCaloJet_Study_n_v_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetNCleanMatchedTracks->at(aodcalojetindex) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
       h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetNCleanMatchedTracks->at(aodcalojetindex) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
-      h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( aodcalojetindex ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
-      h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( aodcalojetindex ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
-      h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( aodcalojetindex ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( 0 ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( 0 ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( 0 ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
 
     }    
   }
   else{
     if( jetbin < (int)aodcalojet_list.size() ){
       int aodcalojetindex = aodcalojet_list[jetbin];
-
-      h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
-      h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+  
+      if(aodcalojetindex==0){
+       h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      }
+      if(AODCaloJetAvfVertexTrackEnergy->at(0)>0.5){
+       h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      }
+      if(AODCaloJetAvfVertexTrackEnergy->at(0)>10.){
+       h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      }
                                                                                                                          
       h_AODCaloJet_Study_n_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetNCleanMatchedTracks->at( aodcalojetindex ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
       h_AODCaloJet_Study_n_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetNCleanMatchedTracks->at( aodcalojetindex ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
       h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetNCleanMatchedTracks->at( aodcalojetindex ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
-      h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetPt->at( aodcalojetindex ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
-      h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetPt->at( aodcalojetindex ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
-      h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetPt->at( aodcalojetindex ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( 0 ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( 0 ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( 0 ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
     }
   }
   

--- a/analyzers/analyzer_histograms.C
+++ b/analyzers/analyzer_histograms.C
@@ -53,6 +53,7 @@ Bool_t analyzer_histograms::fillSelectedJetHistograms(Float_t weight, int selbin
 {
  /// Decide here which jet histograms to get filled
   fillAODCaloJetBasicHistograms( weight, selbin, jetbin );
+  fillAODCaloJetStudyHistograms( weight, selbin, jetbin );
   fillAODCaloJet_L1PFHistograms( weight, selbin, jetbin );
   fillAODCaloJetExtraHistograms( weight, selbin, jetbin );
 }
@@ -62,6 +63,7 @@ Bool_t analyzer_histograms::writeSelectedJetHistograms(int selbin, int jetbin)
 {
  /// Decide here which jet histograms to get written
   writeAODCaloJetBasicHistograms( selbin, jetbin );
+  writeAODCaloJetStudyHistograms( selbin, jetbin );
   writeAODCaloJet_L1PFHistograms( selbin, jetbin );
   writeAODCaloJetExtraHistograms( selbin, jetbin );
 }
@@ -723,6 +725,169 @@ Bool_t analyzer_histograms::deleteAODCaloJetBasicHistograms(int selbin, int jetb
   if(h_AODCaloJetPartonFlavour        [selbin][jetbin]!=NULL)    h_AODCaloJetPartonFlavour                  [selbin][jetbin]->Delete(); 
   if(h_AODCaloJetAbsEta               [selbin][jetbin]!=NULL)    h_AODCaloJetAbsEta                         [selbin][jetbin]->Delete();
   if(h_AODCaloJetPtVarAbsEtaVar       [selbin][jetbin]!=NULL)    h_AODCaloJetPtVarAbsEtaVar                 [selbin][jetbin]->Delete(); 
+ return kTRUE;
+}
+
+
+// Study for the reason behind necessity of the tagging variable shift
+//----------------------------initAODCaloJetStudyHistograms
+Bool_t analyzer_histograms::initAODCaloJetStudyHistograms( TString uncbin )
+{
+
+  // loop through jets and selections to initialize histograms in parllel (series)
+  for(unsigned int i=0; i<selbinnames.size(); ++i){
+  hist_file_out[i]->cd(); 
+  //deleteAODCaloJetStudyHistograms(i);
+      unsigned int k; if(jetMultOn) k=0; else k=jetmultnames.size()-1;
+      for(k; k<jetmultnames.size(); ++k){
+        //deleteAODCaloJetStudyHistograms(i,k);
+        TString hname_AODCaloJet_Study_trk0_AlphaMax                = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_trk0_AlphaMax"               +uncbin ;
+        TString hname_AODCaloJet_Study_trk0_MedianLog10IPSig        = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_trk0_MedianLog10IPSig"       +uncbin ;
+        TString hname_AODCaloJet_Study_trk0_MedianLog10TrackAngle   = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_trk0_MedianLog10TrackAngle"  +uncbin ;
+        TString hname_AODCaloJet_Study_ptG0p5_AlphaMax              = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_ptG0p5_AlphaMax"             +uncbin ;
+        TString hname_AODCaloJet_Study_ptG0p5_MedianLog10IPSig      = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_ptG0p5_MedianLog10IPSig"     +uncbin ;
+        TString hname_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle"+uncbin ;
+        TString hname_AODCaloJet_Study_ptG10_AlphaMax              = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_ptG10_AlphaMax"             +uncbin ;
+        TString hname_AODCaloJet_Study_ptG10_MedianLog10IPSig      = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_ptG10_MedianLog10IPSig"     +uncbin ;
+        TString hname_AODCaloJet_Study_ptG10_MedianLog10TrackAngle = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_ptG10_MedianLog10TrackAngle"+uncbin ;
+                                                                                                      
+        TString hname_AODCaloJet_Study_n_v_AlphaMax                = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_n_v_AlphaMax"               +uncbin ;
+        TString hname_AODCaloJet_Study_n_v_MedianLog10IPSig        = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_n_v_MedianLog10IPSig"       +uncbin ;
+        TString hname_AODCaloJet_Study_n_v_MedianLog10TrackAngle   = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_n_v_MedianLog10TrackAngle"  +uncbin ;
+        TString hname_AODCaloJet_Study_pt_v_AlphaMax                = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_pt_v_AlphaMax"               +uncbin ;
+        TString hname_AODCaloJet_Study_pt_v_MedianLog10IPSig        = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_pt_v_MedianLog10IPSig"       +uncbin ;
+        TString hname_AODCaloJet_Study_pt_v_MedianLog10TrackAngle   = "h_"+selbinnames[i]+"_"+jetmultnames[k]+"_AODCaloJet_Study_pt_v_MedianLog10TrackAngle"  +uncbin ;
+
+        h_AODCaloJet_Study_trk0_AlphaMax               [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_trk0_AlphaMax                , "Study_trk0_AlphaMax"               , 50, 0, 1 );
+        h_AODCaloJet_Study_trk0_MedianLog10IPSig       [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_trk0_MedianLog10IPSig        , "Study_trk0_MedianLog10IPSig"       , 50, -3, 4);
+        h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_trk0_MedianLog10TrackAngle   , "Study_trk0_MedianLog10TrackAngle"  , 50, -5, 2);
+        h_AODCaloJet_Study_ptG0p5_AlphaMax             [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_ptG0p5_AlphaMax              , "Study_ptG0p5_AlphaMax"             , 50, 0, 1 );
+        h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_ptG0p5_MedianLog10IPSig      , "Study_ptG0p5_MedianLog10IPSig"     , 50, -3, 4);
+        h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle , "Study_ptG0p5_MedianLog10TrackAngle", 50, -5, 2);
+        h_AODCaloJet_Study_ptG10_AlphaMax             [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_ptG10_AlphaMax              , "Study_ptG10_AlphaMax"             , 50, 0, 1 );
+        h_AODCaloJet_Study_ptG10_MedianLog10IPSig     [i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_ptG10_MedianLog10IPSig      , "Study_ptG10_MedianLog10IPSig"     , 50, -3, 4);
+        h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle[i][k] = initSingleHistogramTH1F( hname_AODCaloJet_Study_ptG10_MedianLog10TrackAngle , "Study_ptG10_MedianLog10TrackAngle", 50, -5, 2);
+
+	const int Pt_n_xbins = 10;
+	float Pt_xbins[Pt_n_xbins+1] = {0, 10, 20, 30, 40, 50, 75, 100, 150, 250, 500};
+
+        //h_AODCaloJet_Study_pt_v_AlphaMax               [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_pt_v_AlphaMax                ,"Study_pt_v_AlphaMax"               , Pt_n_xbins, Pt_xbins, 50, 0, 1 );
+        //h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_pt_v_MedianLog10IPSig        ,"Study_pt_v_MedianLog10IPSig"       , Pt_n_xbins, Pt_xbins, 50, -3, 4);
+        //h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_pt_v_MedianLog10TrackAngle   ,"Study_pt_v_MedianLog10TrackAngle"  , Pt_n_xbins, Pt_xbins, 50, -5, 2);
+        h_AODCaloJet_Study_pt_v_AlphaMax               [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_pt_v_AlphaMax               , "Study_pt_v_AlphaMax"               , 50, 0, 500, 50, 0, 1 );
+        h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_pt_v_MedianLog10IPSig       , "Study_pt_v_MedianLog10IPSig"       , 50, 0, 500, 50, -3, 4);
+        h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  , "Study_pt_v_MedianLog10TrackAngle"  , 50, 0, 500, 50, -5, 2);
+        h_AODCaloJet_Study_n_v_AlphaMax               [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_n_v_AlphaMax               , "Study_n_v_AlphaMax"               , 15, 0, 15, 50, 0, 1 );
+        h_AODCaloJet_Study_n_v_MedianLog10IPSig       [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_n_v_MedianLog10IPSig       , "Study_n_v_MedianLog10IPSig"       , 15, 0, 15, 50, -3, 4);
+        h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [i][k] = initSingleHistogramTH2F( hname_AODCaloJet_Study_n_v_MedianLog10TrackAngle  , "Study_n_v_MedianLog10TrackAngle"  , 15, 0, 15, 50, -5, 2);
+
+      }
+  }
+  return kTRUE;
+}
+
+//----------------------------fillAODCaloJetStudyHistograms
+Bool_t analyzer_histograms::fillAODCaloJetStudyHistograms(Float_t weight, int selbin, int jetbin)
+{
+  hist_file_out[selbin]->cd();
+  if(jetmultnames.at(jetbin) == "AllJets"){
+    // only fill these once (no jet multiplicity)
+    for(unsigned int i =0; i<aodcalojet_list.size(); i++){
+      int aodcalojetindex = aodcalojet_list[i];
+      //std::cout<<"AODCaloJetAvfVertexTrackEnergy"<<AODCaloJetAvfVertexTrackEnergy->at(aodcalojetindex)<<" "<<aodcalojetindex<<std::endl;
+      if(aodcalojetindex==0){
+       h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      }
+      if(AODCaloJetAvfVertexTrackEnergy->at(aodcalojetindex)>0.5){
+       h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      }
+      if(AODCaloJetAvfVertexTrackEnergy->at(aodcalojetindex)>10.){
+       h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+       h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      }
+                                                                                                                         
+      h_AODCaloJet_Study_n_v_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetNCleanMatchedTracks->at(aodcalojetindex) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_n_v_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetNCleanMatchedTracks->at(aodcalojetindex) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetNCleanMatchedTracks->at(aodcalojetindex) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( aodcalojetindex ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( aodcalojetindex ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetAvfVertexTrackEnergy->at( aodcalojetindex ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
+
+    }    
+  }
+  else{
+    if( jetbin < (int)aodcalojet_list.size() ){
+      int aodcalojetindex = aodcalojet_list[jetbin];
+
+      h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]->Fill( AODCaloJetAlphaMax              ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]->Fill( AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight); 
+      h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]->Fill( AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight); 
+                                                                                                                         
+      h_AODCaloJet_Study_n_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetNCleanMatchedTracks->at( aodcalojetindex ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_n_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetNCleanMatchedTracks->at( aodcalojetindex ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetNCleanMatchedTracks->at( aodcalojetindex ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Fill(AODCaloJetPt->at( aodcalojetindex ) , AODCaloJetAlphaMax              ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Fill(AODCaloJetPt->at( aodcalojetindex ) , AODCaloJetMedianLog10IPSig      ->at(aodcalojetindex), weight);
+      h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Fill(AODCaloJetPt->at( aodcalojetindex ) , AODCaloJetMedianLog10TrackAngle ->at(aodcalojetindex), weight);
+    }
+  }
+  
+  return kTRUE;
+} //end fill histograms
+
+//----------------------------writeAODCaloStudyJetHistograms
+Bool_t analyzer_histograms::writeAODCaloJetStudyHistograms(int selbin, int jetbin)
+{
+  hist_file_out[selbin]->cd();
+  h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_n_v_AlphaMax               [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_n_v_MedianLog10IPSig       [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Write(); 
+  h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Write(); 
+ return kTRUE;
+}
+
+//----------------------------deleteAODCaloJetStudyHistograms
+Bool_t analyzer_histograms::deleteAODCaloJetStudyHistograms(int selbin, int jetbin)
+{
+  hist_file_out[selbin]->cd();
+  //printf("deleteAODCaloJetHistograms\n");
+  if(h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]!=NULL) h_AODCaloJet_Study_trk0_AlphaMax               [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]!=NULL) h_AODCaloJet_Study_trk0_MedianLog10IPSig       [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]!=NULL) h_AODCaloJet_Study_trk0_MedianLog10TrackAngle  [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]!=NULL) h_AODCaloJet_Study_ptG0p5_AlphaMax             [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]!=NULL) h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig     [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]!=NULL) h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle[selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_ptG10_AlphaMax              [selbin][jetbin]!=NULL) h_AODCaloJet_Study_ptG10_AlphaMax             [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_ptG10_MedianLog10IPSig      [selbin][jetbin]!=NULL) h_AODCaloJet_Study_ptG10_MedianLog10IPSig     [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle [selbin][jetbin]!=NULL) h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle[selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_n_v_AlphaMax               [selbin][jetbin]!=NULL) h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_n_v_MedianLog10IPSig       [selbin][jetbin]!=NULL) h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_n_v_MedianLog10TrackAngle  [selbin][jetbin]!=NULL) h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]!=NULL) h_AODCaloJet_Study_pt_v_AlphaMax               [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]!=NULL) h_AODCaloJet_Study_pt_v_MedianLog10IPSig       [selbin][jetbin]->Delete(); 
+  if(h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]!=NULL) h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle  [selbin][jetbin]->Delete(); 
  return kTRUE;
 }
 

--- a/analyzers/analyzer_histograms.h
+++ b/analyzers/analyzer_histograms.h
@@ -107,6 +107,12 @@ public :
  Bool_t        writeAODCaloJetBasicHistograms(int selbin, int jetbin);
  Bool_t        deleteAODCaloJetBasicHistograms(int selbin);
  Bool_t        deleteAODCaloJetBasicHistograms(int selbin, int jetbin);
+ // AODCaloJet Study Variables
+ Bool_t        initAODCaloJetStudyHistograms( TString uncbin );
+ Bool_t        fillAODCaloJetStudyHistograms(Float_t weight, int selbin, int jetbin);
+ Bool_t        writeAODCaloJetStudyHistograms(int selbin, int jetbin);
+ //Bool_t        deleteAODCaloJetStudyHistograms(int selbin);
+ Bool_t        deleteAODCaloJetStudyHistograms(int selbin, int jetbin);
  // AODCaloJet _L1PF Variables
  Bool_t        initAODCaloJet_L1PFHistograms( TString uncbin );
  Bool_t        fillAODCaloJet_L1PFHistograms(Float_t weight, int selbin, int jetbin);
@@ -363,6 +369,24 @@ public :
  TH1F*  h_AODCaloJetPartonFlavour                  [SELBINNAMESIZE][JETMULTNAMESIZE];
  TH1F*  h_AODCaloJetAbsEta                         [SELBINNAMESIZE][JETMULTNAMESIZE];
  TH2F*  h_AODCaloJetPtVarAbsEtaVar                 [SELBINNAMESIZE][JETMULTNAMESIZE];
+
+ // Study tag var shift necessity
+ TH1F*  h_AODCaloJet_Study_trk0_AlphaMax                [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_trk0_MedianLog10IPSig        [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_trk0_MedianLog10TrackAngle   [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_ptG0p5_AlphaMax              [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_ptG0p5_MedianLog10IPSig      [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_ptG0p5_MedianLog10TrackAngle [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_ptG10_AlphaMax               [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_ptG10_MedianLog10IPSig       [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH1F*  h_AODCaloJet_Study_ptG10_MedianLog10TrackAngle  [SELBINNAMESIZE][JETMULTNAMESIZE];
+
+ TH2F*  h_AODCaloJet_Study_n_v_AlphaMax                 [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH2F*  h_AODCaloJet_Study_n_v_MedianLog10IPSig         [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH2F*  h_AODCaloJet_Study_n_v_MedianLog10TrackAngle    [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH2F*  h_AODCaloJet_Study_pt_v_AlphaMax                [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH2F*  h_AODCaloJet_Study_pt_v_MedianLog10IPSig        [SELBINNAMESIZE][JETMULTNAMESIZE];
+ TH2F*  h_AODCaloJet_Study_pt_v_MedianLog10TrackAngle   [SELBINNAMESIZE][JETMULTNAMESIZE];
  
  
  // AODCaloJetL1PFHistograms

--- a/analyzers/main.C
+++ b/analyzers/main.C
@@ -236,22 +236,22 @@ int main(int argc, char **argv){
 
  std::vector<TString> unccategories;
  unccategories.push_back("");
-// if( isMC ){
-//   unccategories.push_back("_EGSUp");
-//   unccategories.push_back("_EGSDown");
-//   unccategories.push_back("_MESUp");
-//   unccategories.push_back("_MESDown");
-//   //unccategories.push_back("_JESUp");
-//   //unccategories.push_back("_JESDown");
-//   unccategories.push_back("_AMaxUp");
-//   unccategories.push_back("_AMaxDown");
-//   unccategories.push_back("_IPSigUp");
-//   unccategories.push_back("_IPSigDown");
-//   unccategories.push_back("_TAUp");
-//   unccategories.push_back("_TADown");
-//   unccategories.push_back("_TagVarsUp");
-//   unccategories.push_back("_TagVarsDown");
-//  }
+ if( isMC ){
+   unccategories.push_back("_EGSUp");
+   unccategories.push_back("_EGSDown");
+   unccategories.push_back("_MESUp");
+   unccategories.push_back("_MESDown");
+   //unccategories.push_back("_JESUp");
+   //unccategories.push_back("_JESDown");
+   unccategories.push_back("_AMaxUp");
+   unccategories.push_back("_AMaxDown");
+   unccategories.push_back("_IPSigUp");
+   unccategories.push_back("_IPSigDown");
+   unccategories.push_back("_TAUp");
+   unccategories.push_back("_TADown");
+   unccategories.push_back("_TagVarsUp");
+   unccategories.push_back("_TagVarsDown");
+  }
  
  // make the analyzer, init some stuff
  analyzer_loop analyzer;

--- a/analyzers/main.C
+++ b/analyzers/main.C
@@ -236,22 +236,22 @@ int main(int argc, char **argv){
 
  std::vector<TString> unccategories;
  unccategories.push_back("");
- if( isMC ){
-   unccategories.push_back("_EGSUp");
-   unccategories.push_back("_EGSDown");
-   unccategories.push_back("_MESUp");
-   unccategories.push_back("_MESDown");
-   //unccategories.push_back("_JESUp");
-   //unccategories.push_back("_JESDown");
-   unccategories.push_back("_AMaxUp");
-   unccategories.push_back("_AMaxDown");
-   unccategories.push_back("_IPSigUp");
-   unccategories.push_back("_IPSigDown");
-   unccategories.push_back("_TAUp");
-   unccategories.push_back("_TADown");
-   unccategories.push_back("_TagVarsUp");
-   unccategories.push_back("_TagVarsDown");
-  }
+// if( isMC ){
+//   unccategories.push_back("_EGSUp");
+//   unccategories.push_back("_EGSDown");
+//   unccategories.push_back("_MESUp");
+//   unccategories.push_back("_MESDown");
+//   //unccategories.push_back("_JESUp");
+//   //unccategories.push_back("_JESDown");
+//   unccategories.push_back("_AMaxUp");
+//   unccategories.push_back("_AMaxDown");
+//   unccategories.push_back("_IPSigUp");
+//   unccategories.push_back("_IPSigDown");
+//   unccategories.push_back("_TAUp");
+//   unccategories.push_back("_TADown");
+//   unccategories.push_back("_TagVarsUp");
+//   unccategories.push_back("_TagVarsDown");
+//  }
  
  // make the analyzer, init some stuff
  analyzer_loop analyzer;
@@ -281,6 +281,7 @@ int main(int argc, char **argv){
   analyzer.initMETHTHistograms( unccategory );
   //analyzer.initExtraHistograms( unccategory );
   analyzer.initAODCaloJetBasicHistograms( unccategory );
+  analyzer.initAODCaloJetStudyHistograms( unccategory );
   analyzer.initAODCaloJet_L1PFHistograms( unccategory );
   analyzer.initAODCaloJetExtraHistograms( unccategory ); 
   analyzer.initAODCaloJetTagHistograms( unccategory ); 


### PR DESCRIPTION
a first pass at some tagging variable histograms with the following selections

 - just leading jet (we don't have individual track info so this is kind of a placeholder for leading track in case we want to put that into some ntuples)
 
- `AODCaloJetAvfVertexTrackEnergy->at(0)>0.5` : this is `energy` as defined in `void lldjNtuple::deltaVertex3D` from `lldjNtuple_AODjets.cc` based off the 4-sum of all cleanTracks . Sometimes this value is 0 so 0.5 gives us a baseline.

- Same with `AODCaloJetAvfVertexTrackEnergy->at(0)>10` (this value isn't optimized)

- 2D plots of tagvar v. `AODCaloJetNCleanMatchedTracks->at(aodcalojetindex)` and tagvar v. `AODCaloJetAvfVertexTrackEnergy->at( 0 )`

